### PR TITLE
(feat) Use NACLs to lock down load balancers

### DIFF
--- a/infra/network_acls.tf
+++ b/infra/network_acls.tf
@@ -1,0 +1,188 @@
+resource "aws_network_acl" "nlb_external" {
+  vpc_id     = "${data.aws_vpc.main.id}"
+  subnet_ids = ["${aws_subnet.public.id}"]
+
+  tags {
+    Name = "${var.name}-nlb-external"
+  }
+}
+
+resource "aws_network_acl_rule" "nlb_external_ingress_command_from_whitelist" {
+  count       = "${length(var.ip_whitelist)}"
+  rule_number = "${1 + length(var.ip_whitelist) * 0 + count.index}"
+
+  network_acl_id = "${aws_network_acl.nlb_external.id}"
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${var.ip_whitelist[count.index]}"
+  from_port      = "${var.ftp_command_port}"
+  to_port        = "${var.ftp_command_port}"
+}
+
+resource "aws_network_acl_rule" "nlb_external_ingress_data_from_whitelist" {
+  count       = "${length(var.ip_whitelist)}"
+  rule_number = "${1 + length(var.ip_whitelist) * 1 + count.index}"
+
+  network_acl_id = "${aws_network_acl.nlb_external.id}"
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${var.ip_whitelist[count.index]}"
+  from_port      = "${var.ftp_data_ports_first}"
+  to_port        = "${var.ftp_data_ports_first + var.ftp_data_ports_count}"
+}
+
+resource "aws_network_acl_rule" "nlb_external_ingress_ephemeral_from_app" {
+  rule_number = "${1 + length(var.ip_whitelist) * 2 + 0}"
+
+  network_acl_id = "${aws_network_acl.nlb_external.id}"
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${aws_subnet.app.cidr_block}"
+  from_port      = "1024"
+  to_port        = "65535"
+}
+
+resource "aws_network_acl_rule" "nlb_external_egress_ephemeral_to_whitelist" {
+  count       = "${length(var.ip_whitelist)}"
+  rule_number = "${1 + length(var.ip_whitelist) * 0 + count.index}"
+
+  network_acl_id = "${aws_network_acl.nlb_external.id}"
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${var.ip_whitelist[count.index]}"
+  from_port      = "1024"
+  to_port        = "65535"
+}
+
+resource "aws_network_acl_rule" "nlb_external_egress_command_to_app" {
+  rule_number = "${1 + length(var.ip_whitelist) * 1 + 0}"
+
+  network_acl_id = "${aws_network_acl.nlb_external.id}"
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${aws_subnet.app.cidr_block}"
+  from_port      = "${var.ftp_command_port}"
+  to_port        = "${var.ftp_command_port}"
+}
+
+resource "aws_network_acl_rule" "nlb_external_egress_data_to_app" {
+  rule_number = "${1 + length(var.ip_whitelist) * 1 + 1}"
+
+  network_acl_id = "${aws_network_acl.nlb_external.id}"
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${aws_subnet.app.cidr_block}"
+  from_port      = "${var.ftp_data_ports_first}"
+  to_port        = "${var.ftp_data_ports_first + var.ftp_data_ports_count}"
+}
+
+resource "aws_network_acl_rule" "nlb_external_egress_healthcheck_to_app" {
+  rule_number = "${1 + length(var.ip_whitelist) * 1 + 2}"
+
+  network_acl_id = "${aws_network_acl.nlb_external.id}"
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${aws_subnet.app.cidr_block}"
+  from_port      = "${var.healthcheck_port}"
+  to_port        = "${var.healthcheck_port}"
+}
+
+resource "aws_network_acl" "nlb_internal" {
+  vpc_id     = "${data.aws_vpc.main.id}"
+  subnet_ids = ["${aws_subnet.private.id}"]
+
+  tags {
+    Name = "${var.name}-nlb-internal"
+  }
+}
+
+resource "aws_network_acl_rule" "nlb_internal_ingress_command_from_vpc_peer" {
+  rule_number = "1"
+
+  network_acl_id = "${aws_network_acl.nlb_internal.id}"
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${data.aws_vpc_peering_connection.private_subnet.cidr_block}"
+  from_port      = "${var.ftp_command_port}"
+  to_port        = "${var.ftp_command_port}"
+}
+
+resource "aws_network_acl_rule" "nlb_internal_ingress_data_from_vpc_peer" {
+  rule_number = "2"
+
+  network_acl_id = "${aws_network_acl.nlb_internal.id}"
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${data.aws_vpc_peering_connection.private_subnet.cidr_block}"
+  from_port      = "${var.ftp_data_ports_first}"
+  to_port        = "${var.ftp_data_ports_first + var.ftp_data_ports_count}"
+}
+
+resource "aws_network_acl_rule" "nlb_internal_ingress_ephemeral_from_app" {
+  rule_number = "3"
+
+  network_acl_id = "${aws_network_acl.nlb_internal.id}"
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${aws_subnet.app.cidr_block}"
+  from_port      = "1024"
+  to_port        = "65535"
+}
+
+resource "aws_network_acl_rule" "nlb_internal_egress_ephemeral_to_vpc_peer" {
+  rule_number = "1"
+
+  network_acl_id = "${aws_network_acl.nlb_internal.id}"
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${data.aws_vpc_peering_connection.private_subnet.cidr_block}"
+  from_port      = "1024"
+  to_port        = "65535"
+}
+
+resource "aws_network_acl_rule" "nlb_internal_egress_command_to_app" {
+  rule_number = "2"
+
+  network_acl_id = "${aws_network_acl.nlb_internal.id}"
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${aws_subnet.app.cidr_block}"
+  from_port      = "${var.ftp_command_port}"
+  to_port        = "${var.ftp_command_port}"
+}
+
+resource "aws_network_acl_rule" "nlb_internal_egress_data_to_app" {
+  rule_number = "3"
+
+  network_acl_id = "${aws_network_acl.nlb_internal.id}"
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${aws_subnet.app.cidr_block}"
+  from_port      = "${var.ftp_data_ports_first}"
+  to_port        = "${var.ftp_data_ports_first + var.ftp_data_ports_count}"
+}
+
+resource "aws_network_acl_rule" "nlb_internal_egress_healthcheck_to_app" {
+  rule_number = "4"
+
+  network_acl_id = "${aws_network_acl.nlb_internal.id}"
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "${aws_subnet.app.cidr_block}"
+  from_port      = "${var.healthcheck_port}"
+  to_port        = "${var.healthcheck_port}"
+}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -8,11 +8,14 @@ resource "aws_security_group" "app_service" {
   }
 }
 
-resource "aws_security_group_rule" "app_service_ingress_command_from_whitelist" {
-  description = "ingress-command-from-whitelist"
+resource "aws_security_group_rule" "app_service_ingress_command_from_nlbs" {
+  description = "ingress-command-from-nlbs"
 
   security_group_id = "${aws_security_group.app_service.id}"
-  cidr_blocks       = ["${var.ip_whitelist}"]
+  cidr_blocks       = [
+    "${aws_subnet.public.cidr_block}",
+    "${aws_subnet.private.cidr_block}",
+  ]
 
   type      = "ingress"
   from_port = "${var.ftp_command_port}"
@@ -20,39 +23,33 @@ resource "aws_security_group_rule" "app_service_ingress_command_from_whitelist" 
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "app_service_ingress_healthcheck_from_nlb_external" {
-  description = "ingress-healthcheck-from-nlb-external"
+resource "aws_security_group_rule" "app_service_ingress_data_from_nlbs" {
+  description = "ingress-command-from-nlbs"
 
   security_group_id = "${aws_security_group.app_service.id}"
-  cidr_blocks       = ["${aws_subnet.public.cidr_block}"]
-
-  type      = "ingress"
-  from_port = "${var.healthcheck_port}"
-  to_port   = "${var.healthcheck_port}"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "app_service_ingress_healthcheck_from_nlb_internal" {
-  description = "ingress-healthcheck-from-nlb-internal"
-
-  security_group_id = "${aws_security_group.app_service.id}"
-  cidr_blocks       = ["${aws_subnet.private.cidr_block}"]
-
-  type      = "ingress"
-  from_port = "${var.healthcheck_port}"
-  to_port   = "${var.healthcheck_port}"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "app_service_ingress_data_from_whitelist" {
-  description = "ingress-data-from-whitelist"
-
-  security_group_id = "${aws_security_group.app_service.id}"
-  cidr_blocks       = ["${var.ip_whitelist}"]
+  cidr_blocks       = [
+    "${aws_subnet.public.cidr_block}",
+    "${aws_subnet.private.cidr_block}",
+  ]
 
   type      = "ingress"
   from_port = "${var.ftp_data_ports_first}"
   to_port   = "${var.ftp_data_ports_first + var.ftp_data_ports_count}"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "app_service_ingress_healthcheck_from_nlbs" {
+  description = "ingress-healthcheck-from-nlbs"
+
+  security_group_id = "${aws_security_group.app_service.id}"
+  cidr_blocks       = [
+    "${aws_subnet.public.cidr_block}",
+    "${aws_subnet.private.cidr_block}",
+  ]
+
+  type      = "ingress"
+  from_port = "${var.healthcheck_port}"
+  to_port   = "${var.healthcheck_port}"
   protocol  = "tcp"
 }
 


### PR DESCRIPTION
It was misunderstood how NLBs work when instances are added by IP (as opposed
to instance ID):

  - The NLBs cannot have a security group associated with them
  - Security groups on the application only block/allow communication based on
    the IP of the NLB, rather than client IP.

This doesn't leave any way to have an IP whitelist for the application, unless
we use network access control lists. Conveniently, each NLB is in its own
subnet, with nothing else in it, so NACLs on those subnets only affect the
NLBs.