### PR TITLE
build(ci): fix minio image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,35 @@ jobs:
   build:
     docker:
       - image: python:3.7.1
-      - image: gcr.io/sre-docker-registry/github.com/uktrade/aioftps3:latest 
+      - image: minio/minio:RELEASE.2018-11-22T02-51-56Z
         environment:
           MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
           MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
           MINIO_REGION: us-east-1
+        entrypoint: sh
+        command: >
+          -c
+          "
+            apk add --no-cache \\
+              openssl=1.0.2t-r0 &&
+            mkdir -p /root/.minio/certs &&
+            mkdir -p /test-data/my-bucket &&
+            mkdir -p /test-data/my-bucket-acme &&
+
+            openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj /CN=selfsigned \\
+              -keyout /root/.minio/certs/private.key \\
+              -out /root/.minio/certs/public.crt &&
+
+            openssl genrsa 4096 > /test-data/my-bucket-acme/account.key &&
+            openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj /CN=selfsigned \\
+              -keyout /test-data/my-bucket-acme/127.0.0.1.key \\
+              -out /test-data/my-bucket-acme/127.0.0.1.crt &&
+
+            openssl req -new -sha256 -key /test-data/my-bucket-acme/127.0.0.1.key -subj /CN=some-domain \\
+              -out /test-data/my-bucket-acme/127.0.0.1.csr &&
+
+            minio server /test-data
+          "
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
The previous move from quay.io to GCR incorrectly also changed what image this was - it should be minio, not the server itself.

This change fixes that, but also avoids having a custom image at all, by using a long command.